### PR TITLE
add dishy.zt.pickardayune.com

### DIFF
--- a/nginx/conf.d/dishy.conf
+++ b/nginx/conf.d/dishy.conf
@@ -1,0 +1,26 @@
+upstream dishy {
+  server 192.168.100.1;
+}
+
+server {
+  listen 80;
+
+  server_name dishy.zt.pickardayune.com;
+  if ($host = dishy.zt.pickardayune.com) {
+    return 301 https://$host$request_uri;
+  }
+  return 404;
+}
+
+server {
+  listen 443 ssl;
+
+  server_name dishy.zt.pickardayune.com;
+
+  ssl_certificate /etc/letsencrypt/live/zt.pickardayune.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/zt.pickardayune.com/privkey.pem;
+
+  location / {
+    proxy_pass http://dishy;
+  }
+}


### PR DESCRIPTION
I wanted to see if I could get to dishy while away from home. This doesn't work because of the way dishy does oauth.

~~If I don't merge this, I'll want to roll back https://github.com/spraints/dns/commit/3e0b7b0f391d7fa2aa30870863ed45e36d996948 too.~~ If I do merge this, I'll need https://github.com/spraints/dns/pull/20, too.